### PR TITLE
Make the route name == the target name

### DIFF
--- a/tests/test_simpleroute.py
+++ b/tests/test_simpleroute.py
@@ -134,3 +134,36 @@ def test_matchdict_class_method():
 
     assert response.content_type == 'application/json'
     assert response.json == {'foo': 'sontek', 'bar': '1'}
+
+
+@pytest.mark.integration
+def test_imperative_route_name():
+    # Test that route_name is same as view name
+    # See https://github.com/sontek/tomb_routes/pull/5
+
+    from tests.simple_app import my_view
+
+    config = _make_config()
+    config.add_simple_route('/path/to/view', my_view, renderer='json')
+
+    route_mapper = config.get_routes_mapper()
+    routes = route_mapper.get_routes()
+
+    assert len(routes) == 1
+    assert routes[0].name == 'my_view'
+
+
+@pytest.mark.integration
+def test_declarative_route_name():
+    config = _make_config()
+    config.scan('tests.simple_app')
+
+    route_mapper = config.get_routes_mapper()
+    routes = route_mapper.get_routes()
+    route_names = [route.name for route in routes]
+
+    assert len(routes) == 4
+    assert 'MyViewsClass.imperative_view' in route_names
+    assert 'MyViewsClass.matchdict_view' in route_names
+    assert 'decorated_view' in route_names
+    assert 'matchdict_view' in route_names

--- a/tomb_routes/__init__.py
+++ b/tomb_routes/__init__.py
@@ -54,15 +54,17 @@ def add_simple_route(
         )
     """
 
-    route_name = path
+    target = DottedNameResolver().maybe_resolve(target)
+
+    route_name = target.__name__
+    if 'attr' in kwargs:
+        route_name += '.' + kwargs['attr']
 
     if append_slash:
         path += '{optional_slash:/?}'
 
     config.add_route(route_name, path)
     kwargs['route_name'] = route_name
-
-    target = DottedNameResolver().maybe_resolve(target)
 
     if append_matchdict and 'mapper' not in kwargs:
         kwargs['mapper'] = MatchdictMapper


### PR DESCRIPTION
instead of the path which likely has slashes in it.

I want the route name to not have slashes in it because I'm thinking of
reviving smlib.viewinfo as tomb_reflect and I have ideas :-)