### PR TITLE
tox.ini: Add py26, py33, pypy3

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist = True
-envlist = py27, py34, pypy, flake8, cov
+envlist = py26, py27, py33, py34, pypy, pypy3, flake8, cov
 
 [base]
 commands =


### PR DESCRIPTION
Might as well...

```
$ tox
...
  py26: commands succeeded
  py27: commands succeeded
  py33: commands succeeded
  py34: commands succeeded
  pypy: commands succeeded
  pypy3: commands succeeded
  flake8: commands succeeded
  cov: commands succeeded
  congratulations :)
```